### PR TITLE
Assure result is an array before looping it

### DIFF
--- a/app/code/community/JeroenVermeulen/Solarium/Model/SelfTest.php
+++ b/app/code/community/JeroenVermeulen/Solarium/Model/SelfTest.php
@@ -130,6 +130,14 @@ class JeroenVermeulen_Solarium_Model_SelfTest
                 $searchResult = $engine->search( $this::TEST_STOREID, $testProductText, $engine::SEARCH_TYPE_LITERAL );
                 $resultDocs   = $searchResult->getResultProducts();
                 $ok           = false;
+                
+                /**
+                 * Make sure it's an array
+                 */
+                if (!is_array($resultDocs)) {
+                    $resultDocs = array();
+                }
+                
                 foreach ($resultDocs as $resultDoc) {
                     if ($testProductId == $resultDoc[ 'product_id' ]) {
                         $ok = true;


### PR DESCRIPTION
When doing self tests in admin that will fail, we need to assure that the result is an array before proceeding.
